### PR TITLE
Removing invalid condition

### DIFF
--- a/library/src/main/java/com/afollestad/digitus/MUtils.java
+++ b/library/src/main/java/com/afollestad/digitus/MUtils.java
@@ -45,7 +45,7 @@ class MUtils {
         int granted = ContextCompat.checkSelfPermission(digitus.mContext, Manifest.permission.USE_FINGERPRINT);
         if (granted != PackageManager.PERMISSION_GRANTED) return false;
         //noinspection ResourceType
-        return digitus.mFingerprintManager.isHardwareDetected() && digitus.mFingerprintManager.hasEnrolledFingerprints();
+        return digitus.mFingerprintManager.isHardwareDetected();
     }
 
     public static void initBase(Context context, DigitusBase digitus) {


### PR DESCRIPTION
"@afollestad if device supports finger print but don't have any digital user register in device the method isFingerprintAuthAvailable return false. It's wrong because device support fingerprint. Are you agree?"

This intent of this statement is correct. isFingerprintAuthAvailable() should not depend on whether the user has at least one fingerprint enrolled. 
